### PR TITLE
feat: add services creation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,12 @@ app/api/            # API routes
 Located in `components/ui/`, built on:
 - React Aria Components for accessibility
 - Tailwind CSS v4 with Untitled UI theme
-- Icons from `@untitledui/icons-react`
+- Icons from `@untitledui/icons` (NOT icons-react)
 
 Import from `@/components/ui`:
 ```typescript
 import { Button, Input, Modal, Table, Badge, Alert } from '@/components/ui'
+import { Plus, Check, Calendar } from '@untitledui/icons' // Not *Icon suffix
 ```
 
 ### Styling

--- a/app/(dashboard)/nomina/colaboradores/[id]/page.tsx
+++ b/app/(dashboard)/nomina/colaboradores/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function CollaboratorDetailPage({
           </span>
         </div>
         <Link
-          href={`/nomina/colaboradores/${collaborator.id}/editar`}
+          href={`/nomina/colaboradores/${collaborator.id}/editar` as '/dashboard'}
           className={cx(
             'inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white',
             'shadow-sm hover:bg-blue-500'

--- a/app/(dashboard)/nomina/page.tsx
+++ b/app/(dashboard)/nomina/page.tsx
@@ -117,7 +117,7 @@ export default async function PayrollPage() {
         {modules.map((module) => (
           <Link
             key={module.href}
-            href={module.href}
+            href={module.href as '/dashboard'}
             className="block rounded-lg bg-white p-6 shadow transition-shadow hover:shadow-lg"
           >
             <div className="flex items-start space-x-4">

--- a/app/(dashboard)/servicios/[id]/page.tsx
+++ b/app/(dashboard)/servicios/[id]/page.tsx
@@ -2,321 +2,485 @@ import { getService } from '@/lib/actions/services'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { cx } from '@/lib/utils/cx'
+import { formatCurrency } from '@/lib/utils/currency'
+import { formatDate, formatDateTime } from '@/lib/utils/date'
+import { formatRut } from '@/lib/utils/rut'
+import { Badge } from '@/components/ui/Badge'
+import { Card, CardHeader, CardContent } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { ArrowLeft as ArrowLeftIcon, Edit03 as EditIcon } from '@untitledui/icons'
 
-export default async function ServiceDetailPage({
-  params,
-}: {
-  params: { id: string }
-}) {
-  let serviceResult
+const SERVICE_TYPE_LABELS: Record<string, string> = {
+  inhumacion: 'Inhumación',
+  cremacion: 'Cremación',
+  traslado_nacional: 'Traslado Nacional',
+  traslado_internacional: 'Traslado Internacional',
+  solo_velatorio: 'Solo Velatorio',
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  borrador: 'Borrador',
+  confirmado: 'Confirmado',
+  en_ejecucion: 'En Ejecución',
+  finalizado: 'Finalizado',
+  cerrado: 'Cerrado',
+}
+
+const STATUS_VARIANTS: Record<string, 'default' | 'primary' | 'success' | 'warning' | 'error'> = {
+  borrador: 'default',
+  confirmado: 'primary',
+  en_ejecucion: 'warning',
+  finalizado: 'success',
+  cerrado: 'default',
+}
+
+export default async function ServiceDetailPage({ params }: { params: { id: string } }) {
+  let service
   try {
-    serviceResult = await getService(params.id)
-  } catch (error) {
+    service = await getService(params.id)
+  } catch {
     notFound()
   }
 
-  if (!serviceResult || !serviceResult.success) {
+  if (!service) {
     notFound()
   }
 
-  const service = serviceResult.data as any
-
-  const paidAmount = service.transactions
-    ?.filter((t: any) => t.status === 'pagado')
-    .reduce((sum: number, t: any) => sum + parseFloat(t.amount || 0), 0) || 0
+  const paidAmount =
+    service.transactions
+      ?.filter((t: any) => t.estado === 'pagado')
+      .reduce((sum: number, t: any) => sum + parseFloat(t.monto || 0), 0) || 0
   const balance = parseFloat(service.total_final || 0) - paidAmount
-
-  const statusColors: Record<string, string> = {
-    borrador: 'bg-gray-100 text-gray-800',
-    confirmado: 'bg-blue-100 text-blue-800',
-    en_ejecucion: 'bg-yellow-100 text-yellow-800',
-    finalizado: 'bg-green-100 text-green-800',
-    cerrado: 'bg-gray-100 text-gray-800',
-  }
 
   return (
     <div className="space-y-6">
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <Link
             href="/servicios"
-            className="text-sm text-gray-500 hover:text-gray-700"
+            className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
           >
-            ← Volver a servicios
+            <ArrowLeftIcon className="mr-1 h-4 w-4" />
+            Volver a servicios
           </Link>
           <h1 className="mt-2 text-2xl font-bold text-gray-900">
-            Servicio {service.service_number}
+            Servicio {service.numero_servicio || '#' + service.id.slice(0, 8)}
           </h1>
         </div>
-        <span
-          className={cx(
-            'inline-flex rounded-full px-3 py-1 text-sm font-semibold',
-            statusColors[service.status] || statusColors.borrador
-          )}
-        >
-          {service.status}
-        </span>
+        <div className="flex items-center gap-3">
+          <Badge size="md" variant={STATUS_VARIANTS[service.estado] || 'default'}>
+            {STATUS_LABELS[service.estado] || service.estado}
+          </Badge>
+          <Link href={`/servicios/${service.id}/editar` as '/dashboard'}>
+            <Button variant="secondary" size="sm">
+              <EditIcon className="mr-1 h-4 w-4" />
+              Editar
+            </Button>
+          </Link>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Main Content */}
-        <div className="lg:col-span-2 space-y-6">
+        <div className="space-y-6 lg:col-span-2">
           {/* Información General */}
-          <section className="rounded-lg bg-white p-6 shadow">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Información General</h2>
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Tipo de Servicio</dt>
-                <dd className="mt-1 text-sm text-gray-900">{service.service_type}</dd>
-              </div>
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Plan</dt>
-                <dd className="mt-1 text-sm text-gray-900">
-                  {service.plan ? service.plan.name : 'Sin plan asignado'}
-                </dd>
-              </div>
-              {service.general_notes && (
-                <div className="sm:col-span-2">
-                  <dt className="text-sm font-medium text-gray-500">Observaciones</dt>
-                  <dd className="mt-1 text-sm text-gray-900">{service.general_notes}</dd>
-                </div>
-              )}
-            </dl>
-          </section>
-
-          {/* Datos del Fallecido */}
-          <section className="rounded-lg bg-white p-6 shadow">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Datos del Fallecido</h2>
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Nombre</dt>
-                <dd className="mt-1 text-sm text-gray-900">{service.deceased_name}</dd>
-              </div>
-              {service.deceased_rut && (
+          <Card>
+            <CardHeader title="Información General" />
+            <CardContent>
+              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div>
-                  <dt className="text-sm font-medium text-gray-500">RUT</dt>
-                  <dd className="mt-1 text-sm text-gray-900">{service.deceased_rut}</dd>
-                </div>
-              )}
-              {service.deceased_birth_date && (
-                <div>
-                  <dt className="text-sm font-medium text-gray-500">Fecha de Nacimiento</dt>
+                  <dt className="text-sm font-medium text-gray-500">Tipo de Servicio</dt>
                   <dd className="mt-1 text-sm text-gray-900">
-                    {new Date(service.deceased_birth_date).toLocaleDateString('es-CL')}
+                    {SERVICE_TYPE_LABELS[service.tipo_servicio] || service.tipo_servicio}
                   </dd>
                 </div>
-              )}
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Fecha de Fallecimiento</dt>
-                <dd className="mt-1 text-sm text-gray-900">
-                  {new Date(service.deceased_death_date).toLocaleDateString('es-CL')}
-                </dd>
-              </div>
-              {service.deceased_death_place && (
-                <div className="sm:col-span-2">
-                  <dt className="text-sm font-medium text-gray-500">Lugar de Fallecimiento</dt>
-                  <dd className="mt-1 text-sm text-gray-900">{service.deceased_death_place}</dd>
-                </div>
-              )}
-            </dl>
-          </section>
-
-          {/* Responsable Económico */}
-          <section className="rounded-lg bg-white p-6 shadow">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Responsable Económico</h2>
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Nombre</dt>
-                <dd className="mt-1 text-sm text-gray-900">{service.responsible_name}</dd>
-              </div>
-              <div>
-                <dt className="text-sm font-medium text-gray-500">RUT</dt>
-                <dd className="mt-1 text-sm text-gray-900">{service.responsible_rut}</dd>
-              </div>
-              <div>
-                <dt className="text-sm font-medium text-gray-500">Teléfono</dt>
-                <dd className="mt-1 text-sm text-gray-900">{service.responsible_phone}</dd>
-              </div>
-              {service.responsible_email && (
                 <div>
-                  <dt className="text-sm font-medium text-gray-500">Email</dt>
-                  <dd className="mt-1 text-sm text-gray-900">{service.responsible_email}</dd>
+                  <dt className="text-sm font-medium text-gray-500">Plan</dt>
+                  <dd className="mt-1 text-sm text-gray-900">
+                    {service.plan ? service.plan.nombre : 'Sin plan asignado'}
+                  </dd>
                 </div>
-              )}
-              {service.responsible_relationship && (
-                <div>
-                  <dt className="text-sm font-medium text-gray-500">Relación</dt>
-                  <dd className="mt-1 text-sm text-gray-900">{service.responsible_relationship}</dd>
-                </div>
-              )}
-            </dl>
-          </section>
-
-          {/* Agenda y Logística */}
-          {(service.wake_start_date || service.burial_cremation_date || service.wake_room) && (
-            <section className="rounded-lg bg-white p-6 shadow">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Agenda y Logística</h2>
-              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                {service.pickup_date && (
+                {service.coffin && (
                   <div>
-                    <dt className="text-sm font-medium text-gray-500">Retiro del Cuerpo</dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      {new Date(service.pickup_date).toLocaleString('es-CL')}
-                    </dd>
+                    <dt className="text-sm font-medium text-gray-500">Ataúd</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.coffin.nombre_comercial}</dd>
                   </div>
                 )}
-                {service.wake_start_date && (
+                {service.urn && (
                   <div>
-                    <dt className="text-sm font-medium text-gray-500">Inicio Velatorio</dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      {new Date(service.wake_start_date).toLocaleString('es-CL')}
-                    </dd>
+                    <dt className="text-sm font-medium text-gray-500">Urna</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.urn.nombre_comercial}</dd>
                   </div>
                 )}
-                {service.wake_room && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Sala de Velación</dt>
-                    <dd className="mt-1 text-sm text-gray-900">{service.wake_room}</dd>
-                  </div>
-                )}
-                {service.burial_cremation_date && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Inhumación/Cremación</dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      {new Date(service.burial_cremation_date).toLocaleString('es-CL')}
-                    </dd>
-                  </div>
-                )}
-                {service.cemetery && (
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Cementerio/Crematorio</dt>
-                    <dd className="mt-1 text-sm text-gray-900">{service.cemetery.name}</dd>
+                {service.notas_generales && (
+                  <div className="sm:col-span-2">
+                    <dt className="text-sm font-medium text-gray-500">Notas Generales</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.notas_generales}</dd>
                   </div>
                 )}
               </dl>
-            </section>
+            </CardContent>
+          </Card>
+
+          {/* Datos del Fallecido */}
+          <Card>
+            <CardHeader title="Datos del Fallecido" />
+            <CardContent>
+              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Nombre Completo</dt>
+                  <dd className="mt-1 text-sm text-gray-900">{service.nombre_fallecido}</dd>
+                </div>
+                {service.rut_fallecido && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">RUT</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{formatRut(service.rut_fallecido)}</dd>
+                  </div>
+                )}
+                {service.fecha_nacimiento_fallecido && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">Fecha de Nacimiento</dt>
+                    <dd className="mt-1 text-sm text-gray-900">
+                      {formatDate(service.fecha_nacimiento_fallecido)}
+                    </dd>
+                  </div>
+                )}
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Fecha de Fallecimiento</dt>
+                  <dd className="mt-1 text-sm text-gray-900">
+                    {formatDate(service.fecha_fallecimiento)}
+                  </dd>
+                </div>
+                {service.tipo_lugar_fallecimiento && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">Tipo de Lugar</dt>
+                    <dd className="mt-1 text-sm text-gray-900 capitalize">
+                      {service.tipo_lugar_fallecimiento.replace('_', ' ')}
+                    </dd>
+                  </div>
+                )}
+                {service.lugar_fallecimiento && (
+                  <div className="sm:col-span-2">
+                    <dt className="text-sm font-medium text-gray-500">Lugar de Fallecimiento</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.lugar_fallecimiento}</dd>
+                  </div>
+                )}
+                {service.causa_fallecimiento && (
+                  <div className="sm:col-span-2">
+                    <dt className="text-sm font-medium text-gray-500">Causa de Fallecimiento</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.causa_fallecimiento}</dd>
+                  </div>
+                )}
+              </dl>
+            </CardContent>
+          </Card>
+
+          {/* Responsable Económico */}
+          <Card>
+            <CardHeader title="Responsable Económico" />
+            <CardContent>
+              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Nombre Completo</dt>
+                  <dd className="mt-1 text-sm text-gray-900">{service.nombre_responsable}</dd>
+                </div>
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">RUT</dt>
+                  <dd className="mt-1 text-sm text-gray-900">{formatRut(service.rut_responsable)}</dd>
+                </div>
+                <div>
+                  <dt className="text-sm font-medium text-gray-500">Teléfono</dt>
+                  <dd className="mt-1 text-sm text-gray-900">{service.telefono_responsable}</dd>
+                </div>
+                {service.email_responsable && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">Email</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.email_responsable}</dd>
+                  </div>
+                )}
+                {service.parentesco_responsable && (
+                  <div>
+                    <dt className="text-sm font-medium text-gray-500">Parentesco</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.parentesco_responsable}</dd>
+                  </div>
+                )}
+                {service.direccion_responsable && (
+                  <div className="sm:col-span-2">
+                    <dt className="text-sm font-medium text-gray-500">Dirección</dt>
+                    <dd className="mt-1 text-sm text-gray-900">{service.direccion_responsable}</dd>
+                  </div>
+                )}
+              </dl>
+            </CardContent>
+          </Card>
+
+          {/* Agenda y Logística */}
+          {(service.fecha_inicio_velatorio ||
+            service.fecha_inhumacion_cremacion ||
+            service.sala_velatorio) && (
+            <Card>
+              <CardHeader title="Agenda y Logística" />
+              <CardContent>
+                <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  {service.fecha_recogida && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Retiro del Cuerpo</dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {formatDateTime(service.fecha_recogida)}
+                      </dd>
+                    </div>
+                  )}
+                  {service.fecha_inicio_velatorio && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Inicio Velatorio</dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {formatDateTime(service.fecha_inicio_velatorio)}
+                      </dd>
+                    </div>
+                  )}
+                  {service.sala_velatorio && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Sala de Velación</dt>
+                      <dd className="mt-1 text-sm text-gray-900">{service.sala_velatorio}</dd>
+                    </div>
+                  )}
+                  {service.fecha_ceremonia_religiosa && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Ceremonia Religiosa</dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {formatDateTime(service.fecha_ceremonia_religiosa)}
+                      </dd>
+                    </div>
+                  )}
+                  {service.fecha_inhumacion_cremacion && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Inhumación/Cremación</dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {formatDateTime(service.fecha_inhumacion_cremacion)}
+                      </dd>
+                    </div>
+                  )}
+                  {service.cemetery && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Cementerio/Crematorio</dt>
+                      <dd className="mt-1 text-sm text-gray-900">{service.cemetery.nombre}</dd>
+                    </div>
+                  )}
+                  {service.main_vehicle && (
+                    <div>
+                      <dt className="text-sm font-medium text-gray-500">Vehículo Principal</dt>
+                      <dd className="mt-1 text-sm text-gray-900">
+                        {service.main_vehicle.placa} - {service.main_vehicle.tipo_vehiculo}
+                      </dd>
+                    </div>
+                  )}
+                  {service.notas_logistica && (
+                    <div className="sm:col-span-2">
+                      <dt className="text-sm font-medium text-gray-500">Notas de Logística</dt>
+                      <dd className="mt-1 text-sm text-gray-900">{service.notas_logistica}</dd>
+                    </div>
+                  )}
+                </dl>
+              </CardContent>
+            </Card>
           )}
 
           {/* Colaboradores */}
           {service.service_assignments && service.service_assignments.length > 0 && (
-            <section className="rounded-lg bg-white p-6 shadow">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Colaboradores Asignados</h2>
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Colaborador
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Rol
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Extra
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200 bg-white">
-                    {service.service_assignments.map((assignment: any) => (
-                      <tr key={assignment.id}>
-                        <td className="whitespace-nowrap px-4 py-4 text-sm text-gray-900">
-                          {assignment.collaborator?.full_name}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-4 text-sm text-gray-500">
-                          {assignment.role_in_service}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-4 text-sm text-gray-900">
-                          ${parseFloat(assignment.extra_amount || 0).toLocaleString('es-CL')}
-                        </td>
+            <Card>
+              <CardHeader title="Colaboradores Asignados" />
+              <CardContent>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                          Colaborador
+                        </th>
+                        <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                          Rol
+                        </th>
+                        <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+                          Extra
+                        </th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
+                    </thead>
+                    <tbody className="divide-y divide-gray-200 bg-white">
+                      {service.service_assignments.map((assignment: any) => (
+                        <tr key={assignment.id}>
+                          <td className="whitespace-nowrap px-4 py-4 text-sm text-gray-900">
+                            {assignment.collaborator?.nombre_completo}
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-4 text-sm text-gray-500">
+                            {assignment.rol_en_servicio}
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-4 text-right text-sm text-gray-900">
+                            {formatCurrency(assignment.monto_extra || 0)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Procedimientos */}
+          {service.service_procedures && service.service_procedures.length > 0 && (
+            <Card>
+              <CardHeader title="Procedimientos" />
+              <CardContent>
+                <div className="space-y-3">
+                  {service.service_procedures.map((proc: any) => (
+                    <div
+                      key={proc.id}
+                      className={cx(
+                        'flex items-center justify-between rounded-lg border p-3',
+                        proc.completado ? 'border-success-200 bg-success-50' : 'border-gray-200'
+                      )}
+                    >
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="checkbox"
+                          checked={proc.completado}
+                          readOnly
+                          className="h-4 w-4 rounded border-gray-300 text-primary-600"
+                        />
+                        <span className={cx('text-sm', proc.completado && 'line-through')}>
+                          {proc.nombre_procedimiento}
+                        </span>
+                      </div>
+                      {proc.fecha_completado && (
+                        <span className="text-xs text-gray-500">
+                          {formatDateTime(proc.fecha_completado)}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
 
         {/* Sidebar */}
         <div className="space-y-6">
           {/* Resumen Financiero */}
-          <section className="rounded-lg bg-white p-6 shadow">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Resumen Financiero</h2>
-            <dl className="space-y-3">
-              <div className="flex justify-between">
-                <dt className="text-sm text-gray-500">Total Items</dt>
-                <dd className="text-sm font-medium text-gray-900">
-                  ${parseFloat(service.total_items || 0).toLocaleString('es-CL')}
-                </dd>
-              </div>
-              {(service.discount_amount > 0 || service.discount_percentage > 0) && (
+          <Card>
+            <CardHeader title="Resumen Financiero" />
+            <CardContent>
+              <dl className="space-y-3">
                 <div className="flex justify-between">
-                  <dt className="text-sm text-gray-500">Descuento</dt>
-                  <dd className="text-sm font-medium text-red-600">
-                    -${parseFloat(service.discount_amount || 0).toLocaleString('es-CL')}
-                    {service.discount_percentage > 0 && ` (${service.discount_percentage}%)`}
+                  <dt className="text-sm text-gray-500">Total Items</dt>
+                  <dd className="text-sm font-medium text-gray-900">
+                    {formatCurrency(service.total_items || 0)}
                   </dd>
                 </div>
-              )}
-              <div className="border-t border-gray-200 pt-3">
+                {(service.monto_descuento > 0 || service.porcentaje_descuento > 0) && (
+                  <div className="flex justify-between">
+                    <dt className="text-sm text-gray-500">Descuento</dt>
+                    <dd className="text-sm font-medium text-error-600">
+                      -{formatCurrency(service.monto_descuento || 0)}
+                      {service.porcentaje_descuento > 0 && ` (${service.porcentaje_descuento}%)`}
+                    </dd>
+                  </div>
+                )}
+                <div className="border-t border-gray-200 pt-3">
+                  <div className="flex justify-between">
+                    <dt className="text-base font-semibold text-gray-900">Total Final</dt>
+                    <dd className="text-base font-bold text-gray-900">
+                      {formatCurrency(service.total_final || 0)}
+                    </dd>
+                  </div>
+                </div>
                 <div className="flex justify-between">
-                  <dt className="text-base font-semibold text-gray-900">Total Final</dt>
-                  <dd className="text-base font-bold text-gray-900">
-                    ${parseFloat(service.total_final || 0).toLocaleString('es-CL')}
+                  <dt className="text-sm text-gray-500">Pagado</dt>
+                  <dd className="text-sm font-medium text-success-600">
+                    {formatCurrency(paidAmount)}
                   </dd>
                 </div>
-              </div>
-              <div className="flex justify-between">
-                <dt className="text-sm text-gray-500">Pagado</dt>
-                <dd className="text-sm font-medium text-green-600">
-                  ${paidAmount.toLocaleString('es-CL')}
-                </dd>
-              </div>
-              <div className="border-t border-gray-200 pt-3">
-                <div className="flex justify-between">
-                  <dt className="text-base font-semibold text-gray-900">Saldo Pendiente</dt>
-                  <dd className={cx(
-                    "text-base font-bold",
-                    balance > 0 ? "text-red-600" : "text-green-600"
-                  )}>
-                    ${balance.toLocaleString('es-CL')}
-                  </dd>
+                <div className="border-t border-gray-200 pt-3">
+                  <div className="flex justify-between">
+                    <dt className="text-base font-semibold text-gray-900">Saldo Pendiente</dt>
+                    <dd
+                      className={cx(
+                        'text-base font-bold',
+                        balance > 0 ? 'text-error-600' : 'text-success-600'
+                      )}
+                    >
+                      {formatCurrency(balance)}
+                    </dd>
+                  </div>
                 </div>
-              </div>
-            </dl>
-          </section>
+              </dl>
+            </CardContent>
+          </Card>
 
           {/* Transacciones */}
           {service.transactions && service.transactions.length > 0 && (
-            <section className="rounded-lg bg-white p-6 shadow">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Transacciones</h2>
-              <div className="space-y-3">
-                {service.transactions.map((transaction: any) => (
-                  <div key={transaction.id} className="border-b border-gray-200 pb-3 last:border-0">
-                    <div className="flex justify-between text-sm">
-                      <span className="text-gray-900">
-                        {new Date(transaction.transaction_date).toLocaleDateString('es-CL')}
-                      </span>
-                      <span className="font-medium text-gray-900">
-                        ${parseFloat(transaction.amount).toLocaleString('es-CL')}
-                      </span>
+            <Card>
+              <CardHeader title="Transacciones" />
+              <CardContent>
+                <div className="space-y-3">
+                  {service.transactions.map((transaction: any) => (
+                    <div key={transaction.id} className="border-b border-gray-200 pb-3 last:border-0">
+                      <div className="flex justify-between text-sm">
+                        <span className="text-gray-900">
+                          {formatDate(transaction.fecha_transaccion)}
+                        </span>
+                        <span className="font-medium text-gray-900">
+                          {formatCurrency(transaction.monto)}
+                        </span>
+                      </div>
+                      <div className="mt-1 flex justify-between text-xs text-gray-500">
+                        <span className="capitalize">{transaction.metodo_pago?.replace('_', ' ')}</span>
+                        <Badge
+                          size="sm"
+                          variant={transaction.estado === 'pagado' ? 'success' : 'warning'}
+                        >
+                          {transaction.estado}
+                        </Badge>
+                      </div>
                     </div>
-                    <div className="mt-1 flex justify-between text-xs text-gray-500">
-                      <span>{transaction.payment_method}</span>
-                      <span className={cx(
-                        transaction.status === 'pagado' ? 'text-green-600' : 'text-yellow-600'
-                      )}>
-                        {transaction.status}
-                      </span>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Documentos */}
+          {service.documents && service.documents.length > 0 && (
+            <Card>
+              <CardHeader title="Documentos" />
+              <CardContent>
+                <div className="space-y-2">
+                  {service.documents.map((doc: any) => (
+                    <div
+                      key={doc.id}
+                      className="flex items-center justify-between rounded border border-gray-200 p-2"
+                    >
+                      <div className="text-sm">
+                        <div className="font-medium text-gray-900">{doc.nombre_archivo}</div>
+                        <div className="text-xs text-gray-500">{doc.tipo_documento}</div>
+                      </div>
+                      <a
+                        href={doc.url_archivo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-primary-600 hover:text-primary-800"
+                      >
+                        Ver
+                      </a>
                     </div>
-                  </div>
-                ))}
-              </div>
-            </section>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
           )}
         </div>
       </div>
     </div>
   )
 }
-

--- a/app/(dashboard)/servicios/nuevo/page.tsx
+++ b/app/(dashboard)/servicios/nuevo/page.tsx
@@ -1,0 +1,67 @@
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { getUserBranches, getUserProfile } from '@/lib/actions/branches'
+import { getCatalogData } from '@/lib/actions/services'
+import { ServiceForm } from '@/components/services/ServiceForm'
+import { ArrowLeft as ArrowLeftIcon } from '@untitledui/icons'
+
+export default async function NewServicePage() {
+  const [profile, branches, catalogData] = await Promise.all([
+    getUserProfile(),
+    getUserBranches(),
+    getCatalogData(),
+  ])
+
+  if (!profile) {
+    redirect('/login')
+  }
+
+  if (!branches || branches.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-lg bg-yellow-50 p-4">
+          <div className="flex">
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-yellow-800">Sin sucursales asignadas</h3>
+              <div className="mt-2 text-sm text-yellow-700">
+                <p>No tienes sucursales asignadas. Contacta al administrador para poder crear servicios.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const formattedBranches = branches.map((b) => ({
+    id: b.id,
+    nombre: b.nombre,
+  }))
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Link
+          href="/servicios"
+          className="inline-flex items-center text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeftIcon className="mr-1 h-4 w-4" />
+          Volver a Servicios
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Nuevo Servicio</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Complete los datos del servicio funerario. Los campos marcados con * son obligatorios.
+        </p>
+      </div>
+
+      <ServiceForm
+        funeralHomeId={profile.funeral_home_id}
+        branches={formattedBranches}
+        catalogData={catalogData}
+      />
+    </div>
+  )
+}

--- a/components/dashboard/AlertsPanel.tsx
+++ b/components/dashboard/AlertsPanel.tsx
@@ -97,7 +97,7 @@ function AlertItemComponent({ alert }: { alert: AlertItem }) {
 
   if (alert.enlace) {
     return (
-      <Link href={alert.enlace} className="block">
+      <Link href={alert.enlace as '/dashboard'} className="block">
         {content}
       </Link>
     )

--- a/components/services/ServiceForm.tsx
+++ b/components/services/ServiceForm.tsx
@@ -1,0 +1,655 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { Select, SelectOption } from '@/components/ui/Select'
+import { TextArea } from '@/components/ui/TextArea'
+import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/Card'
+import { Alert } from '@/components/ui/Alert'
+import { serviceCreateSchema, type ServiceCreateInput } from '@/lib/validations/service'
+import { createService, updateService } from '@/lib/actions/services'
+import { formatRutInput } from '@/lib/utils/rut'
+import { cx } from '@/lib/utils/cx'
+import {
+  Check as CheckIcon,
+  User01 as UserIcon,
+  Calendar as CalendarIcon,
+  CreditCard01 as CreditCardIcon,
+  MarkerPin01 as MapPinIcon,
+} from '@untitledui/icons'
+
+interface CatalogData {
+  plans: Array<{ id: string; nombre: string; precio_base: number; descripcion?: string }>
+  coffins: Array<{
+    id: string
+    nombre_comercial: string
+    precio_venta: number
+    categoria?: string
+    tamano?: string
+  }>
+  urns: Array<{ id: string; nombre_comercial: string; precio_venta: number; categoria?: string }>
+  cemeteries: Array<{ id: string; nombre: string; tipo: string; direccion?: string }>
+  vehicles: Array<{ id: string; placa: string; tipo_vehiculo: string; capacidad?: number }>
+}
+
+interface UserBranch {
+  id: string
+  nombre: string
+}
+
+interface ServiceFormProps {
+  funeralHomeId: string
+  branches: UserBranch[]
+  catalogData: CatalogData
+  initialData?: Partial<ServiceCreateInput> & { id?: string }
+  mode?: 'create' | 'edit'
+}
+
+const STEPS = [
+  { id: 1, name: 'Información General', icon: UserIcon },
+  { id: 2, name: 'Datos del Fallecido', icon: UserIcon },
+  { id: 3, name: 'Responsable', icon: UserIcon },
+  { id: 4, name: 'Plan y Productos', icon: CreditCardIcon },
+  { id: 5, name: 'Agenda y Logística', icon: CalendarIcon },
+]
+
+const SERVICE_TYPES: SelectOption[] = [
+  { value: 'inhumacion', label: 'Inhumación' },
+  { value: 'cremacion', label: 'Cremación' },
+  { value: 'traslado_nacional', label: 'Traslado Nacional' },
+  { value: 'traslado_internacional', label: 'Traslado Internacional' },
+  { value: 'solo_velatorio', label: 'Solo Velatorio' },
+]
+
+const DEATH_PLACE_TYPES: SelectOption[] = [
+  { value: '', label: 'Seleccionar...' },
+  { value: 'domicilio', label: 'Domicilio' },
+  { value: 'hospital', label: 'Hospital' },
+  { value: 'via_publica', label: 'Vía Pública' },
+  { value: 'otro', label: 'Otro' },
+]
+
+export function ServiceForm({
+  funeralHomeId,
+  branches,
+  catalogData,
+  initialData,
+  mode = 'create',
+}: ServiceFormProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [currentStep, setCurrentStep] = useState(1)
+  const [error, setError] = useState<string | null>(null)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+    watch,
+    trigger,
+  } = useForm<ServiceCreateInput>({
+    // @ts-expect-error - Zod v4 and @hookform/resolvers type mismatch
+    resolver: zodResolver(serviceCreateSchema),
+    defaultValues: {
+      funeral_home_id: funeralHomeId,
+      branch_id: initialData?.branch_id || branches[0]?.id || '',
+      tipo_servicio: initialData?.tipo_servicio || 'inhumacion',
+      estado: initialData?.estado || 'borrador',
+      nombre_fallecido: initialData?.nombre_fallecido || '',
+      fecha_fallecimiento: initialData?.fecha_fallecimiento || '',
+      nombre_responsable: initialData?.nombre_responsable || '',
+      rut_responsable: initialData?.rut_responsable || '',
+      telefono_responsable: initialData?.telefono_responsable || '',
+      monto_descuento: initialData?.monto_descuento || 0,
+      porcentaje_descuento: initialData?.porcentaje_descuento || 0,
+      ...initialData,
+    },
+  })
+
+  const selectedPlanId = watch('plan_id')
+  const selectedCoffinId = watch('coffin_id')
+  const selectedUrnId = watch('urn_id')
+  const tipoServicio = watch('tipo_servicio')
+
+  // Calculate total based on selections
+  const calculateTotal = () => {
+    let total = 0
+    const plan = catalogData.plans.find((p) => p.id === selectedPlanId)
+    const coffin = catalogData.coffins.find((c) => c.id === selectedCoffinId)
+    const urn = catalogData.urns.find((u) => u.id === selectedUrnId)
+
+    if (plan) total += plan.precio_base
+    if (coffin) total += coffin.precio_venta
+    if (urn) total += urn.precio_venta
+
+    return total
+  }
+
+  const handleRutChange = (field: 'rut_fallecido' | 'rut_responsable') => (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const formatted = formatRutInput(e.target.value)
+    setValue(field, formatted)
+  }
+
+  const validateCurrentStep = async () => {
+    let fieldsToValidate: (keyof ServiceCreateInput)[] = []
+
+    switch (currentStep) {
+      case 1:
+        fieldsToValidate = ['branch_id', 'tipo_servicio']
+        break
+      case 2:
+        fieldsToValidate = ['nombre_fallecido', 'fecha_fallecimiento']
+        break
+      case 3:
+        fieldsToValidate = ['nombre_responsable', 'rut_responsable', 'telefono_responsable']
+        break
+      case 4:
+        // Optional fields
+        break
+      case 5:
+        // Optional fields
+        break
+    }
+
+    if (fieldsToValidate.length === 0) return true
+    return await trigger(fieldsToValidate)
+  }
+
+  const handleNext = async () => {
+    const isValid = await validateCurrentStep()
+    if (isValid && currentStep < STEPS.length) {
+      setCurrentStep(currentStep + 1)
+    }
+  }
+
+  const handlePrevious = () => {
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1)
+    }
+  }
+
+  const onSubmit = (data: ServiceCreateInput) => {
+    setError(null)
+    startTransition(async () => {
+      try {
+        const result =
+          mode === 'edit' && initialData?.id
+            ? await updateService(initialData.id, data)
+            : await createService(data)
+
+        if (result.success) {
+          router.push('/servicios')
+          router.refresh()
+        } else {
+          setError(result.error.message)
+        }
+      } catch (err) {
+        setError('Ha ocurrido un error inesperado')
+      }
+    })
+  }
+
+  const branchOptions: SelectOption[] = branches.map((b) => ({
+    value: b.id,
+    label: b.nombre,
+  }))
+
+  const planOptions: SelectOption[] = [
+    { value: '', label: 'Sin plan' },
+    ...catalogData.plans.map((p) => ({
+      value: p.id,
+      label: `${p.nombre} - $${p.precio_base.toLocaleString('es-CL')}`,
+    })),
+  ]
+
+  const coffinOptions: SelectOption[] = [
+    { value: '', label: 'Sin ataúd' },
+    ...catalogData.coffins.map((c) => ({
+      value: c.id,
+      label: `${c.nombre_comercial} - $${c.precio_venta.toLocaleString('es-CL')}`,
+    })),
+  ]
+
+  const urnOptions: SelectOption[] = [
+    { value: '', label: 'Sin urna' },
+    ...catalogData.urns.map((u) => ({
+      value: u.id,
+      label: `${u.nombre_comercial} - $${u.precio_venta.toLocaleString('es-CL')}`,
+    })),
+  ]
+
+  const cemeteryOptions: SelectOption[] = [
+    { value: '', label: 'Seleccionar...' },
+    ...catalogData.cemeteries.map((c) => ({
+      value: c.id,
+      label: `${c.nombre} (${c.tipo})`,
+    })),
+  ]
+
+  const vehicleOptions: SelectOption[] = [
+    { value: '', label: 'Seleccionar...' },
+    ...catalogData.vehicles.map((v) => ({
+      value: v.id,
+      label: `${v.placa} - ${v.tipo_vehiculo}`,
+    })),
+  ]
+
+  return (
+    // @ts-expect-error - FieldValues type inference issue
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Card padding="none" className="overflow-hidden">
+        {/* Step Indicator */}
+        <div className="border-b border-gray-200 bg-gray-50 px-6 py-4">
+          <nav aria-label="Progress">
+            <ol className="flex items-center">
+              {STEPS.map((step, stepIdx) => (
+                <li
+                  key={step.id}
+                  className={cx(stepIdx !== STEPS.length - 1 ? 'flex-1' : '', 'relative')}
+                >
+                  <div className="flex items-center">
+                    <div
+                      className={cx(
+                        'relative flex h-10 w-10 items-center justify-center rounded-full',
+                        currentStep > step.id
+                          ? 'bg-primary-600'
+                          : currentStep === step.id
+                            ? 'border-2 border-primary-600 bg-white'
+                            : 'border-2 border-gray-300 bg-white'
+                      )}
+                    >
+                      {currentStep > step.id ? (
+                        <CheckIcon className="h-5 w-5 text-white" />
+                      ) : (
+                        <step.icon
+                          className={cx(
+                            'h-5 w-5',
+                            currentStep === step.id ? 'text-primary-600' : 'text-gray-500'
+                          )}
+                        />
+                      )}
+                    </div>
+                    {stepIdx !== STEPS.length - 1 && (
+                      <div
+                        className={cx(
+                          'ml-4 h-0.5 flex-1',
+                          currentStep > step.id ? 'bg-primary-600' : 'bg-gray-300'
+                        )}
+                      />
+                    )}
+                  </div>
+                  <div className="mt-2">
+                    <span
+                      className={cx(
+                        'text-xs font-medium',
+                        currentStep === step.id ? 'text-primary-600' : 'text-gray-500'
+                      )}
+                    >
+                      Paso {step.id}
+                    </span>
+                    <p
+                      className={cx(
+                        'text-sm',
+                        currentStep === step.id ? 'font-medium text-gray-900' : 'text-gray-500'
+                      )}
+                    >
+                      {step.name}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </nav>
+        </div>
+
+        {error && (
+          <div className="px-6 pt-4">
+            <Alert variant="error" title="Error">
+              {error}
+            </Alert>
+          </div>
+        )}
+
+        <CardContent className="min-h-[400px] p-6">
+          {/* Step 1: General Information */}
+          {currentStep === 1 && (
+            <div className="space-y-6">
+              <h3 className="text-lg font-medium text-gray-900">Información General</h3>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Select
+                  label="Sucursal"
+                  options={branchOptions}
+                  selectedKey={watch('branch_id')}
+                  onSelectionChange={(key) => setValue('branch_id', key as string)}
+                  errorMessage={errors.branch_id?.message}
+                  required
+                />
+                <Select
+                  label="Tipo de Servicio"
+                  options={SERVICE_TYPES}
+                  selectedKey={watch('tipo_servicio')}
+                  onSelectionChange={(key) =>
+                    setValue('tipo_servicio', key as ServiceCreateInput['tipo_servicio'])
+                  }
+                  errorMessage={errors.tipo_servicio?.message}
+                  required
+                />
+              </div>
+              <TextArea
+                label="Notas Generales"
+                {...register('notas_generales')}
+                errorMessage={errors.notas_generales?.message}
+                placeholder="Observaciones o notas adicionales sobre el servicio..."
+              />
+            </div>
+          )}
+
+          {/* Step 2: Deceased Information */}
+          {currentStep === 2 && (
+            <div className="space-y-6">
+              <h3 className="text-lg font-medium text-gray-900">Datos del Fallecido</h3>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Input
+                  label="Nombre Completo"
+                  {...register('nombre_fallecido')}
+                  errorMessage={errors.nombre_fallecido?.message}
+                  required
+                />
+                <Input
+                  label="RUT"
+                  value={watch('rut_fallecido') || ''}
+                  onChange={handleRutChange('rut_fallecido')}
+                  errorMessage={errors.rut_fallecido?.message}
+                  placeholder="12.345.678-9"
+                />
+                <Input
+                  label="Fecha de Nacimiento"
+                  type="date"
+                  {...register('fecha_nacimiento_fallecido')}
+                  errorMessage={errors.fecha_nacimiento_fallecido?.message}
+                />
+                <Input
+                  label="Fecha de Fallecimiento"
+                  type="date"
+                  {...register('fecha_fallecimiento')}
+                  errorMessage={errors.fecha_fallecimiento?.message}
+                  required
+                />
+                <Select
+                  label="Tipo de Lugar de Fallecimiento"
+                  options={DEATH_PLACE_TYPES}
+                  selectedKey={watch('tipo_lugar_fallecimiento') || ''}
+                  onSelectionChange={(key) =>
+                    setValue(
+                      'tipo_lugar_fallecimiento',
+                      key as ServiceCreateInput['tipo_lugar_fallecimiento']
+                    )
+                  }
+                  errorMessage={errors.tipo_lugar_fallecimiento?.message}
+                />
+                <Input
+                  label="Lugar de Fallecimiento"
+                  {...register('lugar_fallecimiento')}
+                  errorMessage={errors.lugar_fallecimiento?.message}
+                  placeholder="Dirección o nombre del lugar"
+                />
+              </div>
+              <TextArea
+                label="Causa de Fallecimiento"
+                {...register('causa_fallecimiento')}
+                errorMessage={errors.causa_fallecimiento?.message}
+                placeholder="Causa médica del fallecimiento"
+              />
+            </div>
+          )}
+
+          {/* Step 3: Responsible Person */}
+          {currentStep === 3 && (
+            <div className="space-y-6">
+              <h3 className="text-lg font-medium text-gray-900">Datos del Responsable</h3>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Input
+                  label="Nombre Completo"
+                  {...register('nombre_responsable')}
+                  errorMessage={errors.nombre_responsable?.message}
+                  required
+                />
+                <Input
+                  label="RUT"
+                  value={watch('rut_responsable') || ''}
+                  onChange={handleRutChange('rut_responsable')}
+                  errorMessage={errors.rut_responsable?.message}
+                  placeholder="12.345.678-9"
+                  required
+                />
+                <Input
+                  label="Teléfono"
+                  type="tel"
+                  {...register('telefono_responsable')}
+                  errorMessage={errors.telefono_responsable?.message}
+                  placeholder="+56 9 1234 5678"
+                  required
+                />
+                <Input
+                  label="Email"
+                  type="email"
+                  {...register('email_responsable')}
+                  errorMessage={errors.email_responsable?.message}
+                  placeholder="correo@ejemplo.cl"
+                />
+                <Input
+                  label="Parentesco"
+                  {...register('parentesco_responsable')}
+                  errorMessage={errors.parentesco_responsable?.message}
+                  placeholder="Ej: Hijo, Esposo, etc."
+                />
+                <div className="md:col-span-2">
+                  <Input
+                    label="Dirección"
+                    {...register('direccion_responsable')}
+                    errorMessage={errors.direccion_responsable?.message}
+                    placeholder="Dirección completa"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 4: Plan and Products */}
+          {currentStep === 4 && (
+            <div className="space-y-6">
+              <h3 className="text-lg font-medium text-gray-900">Plan y Productos</h3>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Select
+                  label="Plan de Servicio"
+                  options={planOptions}
+                  selectedKey={watch('plan_id') || ''}
+                  onSelectionChange={(key) => setValue('plan_id', key as string || null)}
+                  errorMessage={errors.plan_id?.message}
+                />
+                <Select
+                  label="Ataúd"
+                  options={coffinOptions}
+                  selectedKey={watch('coffin_id') || ''}
+                  onSelectionChange={(key) => setValue('coffin_id', key as string || null)}
+                  errorMessage={errors.coffin_id?.message}
+                />
+                {(tipoServicio === 'cremacion' || tipoServicio === 'solo_velatorio') && (
+                  <Select
+                    label="Urna"
+                    options={urnOptions}
+                    selectedKey={watch('urn_id') || ''}
+                    onSelectionChange={(key) => setValue('urn_id', key as string || null)}
+                    errorMessage={errors.urn_id?.message}
+                  />
+                )}
+              </div>
+
+              <div className="rounded-lg bg-gray-50 p-4">
+                <h4 className="text-sm font-medium text-gray-700">Resumen de Precios</h4>
+                <div className="mt-2 space-y-2">
+                  {selectedPlanId && (
+                    <div className="flex justify-between text-sm">
+                      <span>Plan:</span>
+                      <span>
+                        $
+                        {catalogData.plans
+                          .find((p) => p.id === selectedPlanId)
+                          ?.precio_base.toLocaleString('es-CL')}
+                      </span>
+                    </div>
+                  )}
+                  {selectedCoffinId && (
+                    <div className="flex justify-between text-sm">
+                      <span>Ataúd:</span>
+                      <span>
+                        $
+                        {catalogData.coffins
+                          .find((c) => c.id === selectedCoffinId)
+                          ?.precio_venta.toLocaleString('es-CL')}
+                      </span>
+                    </div>
+                  )}
+                  {selectedUrnId && (
+                    <div className="flex justify-between text-sm">
+                      <span>Urna:</span>
+                      <span>
+                        $
+                        {catalogData.urns
+                          .find((u) => u.id === selectedUrnId)
+                          ?.precio_venta.toLocaleString('es-CL')}
+                      </span>
+                    </div>
+                  )}
+                  <div className="border-t pt-2">
+                    <div className="flex justify-between font-medium">
+                      <span>Subtotal:</span>
+                      <span>${calculateTotal().toLocaleString('es-CL')}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Input
+                  label="Descuento (Monto)"
+                  type="number"
+                  {...register('monto_descuento', { valueAsNumber: true })}
+                  errorMessage={errors.monto_descuento?.message}
+                />
+                <Input
+                  label="Descuento (%)"
+                  type="number"
+                  {...register('porcentaje_descuento', { valueAsNumber: true })}
+                  errorMessage={errors.porcentaje_descuento?.message}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Step 5: Agenda and Logistics */}
+          {currentStep === 5 && (
+            <div className="space-y-6">
+              <h3 className="text-lg font-medium text-gray-900">Agenda y Logística</h3>
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <Input
+                  label="Fecha de Recogida"
+                  type="datetime-local"
+                  {...register('fecha_recogida')}
+                  errorMessage={errors.fecha_recogida?.message}
+                />
+                <Input
+                  label="Inicio de Velatorio"
+                  type="datetime-local"
+                  {...register('fecha_inicio_velatorio')}
+                  errorMessage={errors.fecha_inicio_velatorio?.message}
+                />
+                <Input
+                  label="Sala de Velatorio"
+                  {...register('sala_velatorio')}
+                  errorMessage={errors.sala_velatorio?.message}
+                  placeholder="Ej: Sala Norte"
+                />
+                <Input
+                  label="Ceremonia Religiosa"
+                  type="datetime-local"
+                  {...register('fecha_ceremonia_religiosa')}
+                  errorMessage={errors.fecha_ceremonia_religiosa?.message}
+                />
+                <Input
+                  label="Fecha de Inhumación/Cremación"
+                  type="datetime-local"
+                  {...register('fecha_inhumacion_cremacion')}
+                  errorMessage={errors.fecha_inhumacion_cremacion?.message}
+                />
+                <Select
+                  label="Cementerio/Crematorio"
+                  options={cemeteryOptions}
+                  selectedKey={watch('cemetery_crematorium_id') || ''}
+                  onSelectionChange={(key) =>
+                    setValue('cemetery_crematorium_id', key as string || null)
+                  }
+                  errorMessage={errors.cemetery_crematorium_id?.message}
+                />
+                <Select
+                  label="Vehículo Principal"
+                  options={vehicleOptions}
+                  selectedKey={watch('vehiculo_principal_id') || ''}
+                  onSelectionChange={(key) =>
+                    setValue('vehiculo_principal_id', key as string || null)
+                  }
+                  errorMessage={errors.vehiculo_principal_id?.message}
+                />
+              </div>
+              <TextArea
+                label="Notas de Logística"
+                {...register('notas_logistica')}
+                errorMessage={errors.notas_logistica?.message}
+                placeholder="Instrucciones especiales, rutas, consideraciones..."
+              />
+            </div>
+          )}
+        </CardContent>
+
+        <CardFooter className="border-t bg-gray-50 px-6 py-4">
+          <div className="flex w-full justify-between">
+            <Button
+              type="button"
+              variant="secondary"
+              onPress={handlePrevious}
+              isDisabled={currentStep === 1}
+            >
+              Anterior
+            </Button>
+            <div className="flex gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                onPress={() => router.push('/servicios')}
+                isDisabled={isPending}
+              >
+                Cancelar
+              </Button>
+              {currentStep < STEPS.length ? (
+                <Button type="button" onPress={handleNext}>
+                  Siguiente
+                </Button>
+              ) : (
+                <Button type="submit" isLoading={isPending} loadingText="Guardando...">
+                  {mode === 'create' ? 'Crear Servicio' : 'Guardar Cambios'}
+                </Button>
+              )}
+            </div>
+          </div>
+        </CardFooter>
+      </Card>
+    </form>
+  )
+}

--- a/lib/actions/branches.ts
+++ b/lib/actions/branches.ts
@@ -341,3 +341,60 @@ export async function getBranchStats(branchId: string) {
     total_services: servicesResult.count || 0,
   }
 }
+
+export async function getUserBranches() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return []
+  }
+
+  const { data, error } = await supabase
+    .from('user_branches')
+    .select(`
+      branch_id,
+      branches (
+        id,
+        nombre,
+        direccion,
+        telefono,
+        email,
+        activa
+      )
+    `)
+    .eq('user_id', user.id)
+
+  if (error || !data) {
+    return []
+  }
+
+  return data.map((ub: any) => ub.branches).filter(Boolean)
+}
+
+export async function getUserProfile() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return null
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .single()
+
+  if (error) {
+    return null
+  }
+
+  return data
+}

--- a/lib/actions/services.ts
+++ b/lib/actions/services.ts
@@ -2,155 +2,144 @@
 
 import { createClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
-import { serviceSchema } from '@/lib/validations/service'
-import type { ServiceInput } from '@/lib/validations/service'
-import { ActionResult, success, failure, getErrorMessage, logError, extractZodErrors } from '@/lib/utils/errors'
-import { ZodError } from 'zod'
+import { serviceCreateSchema, serviceUpdateSchema } from '@/lib/validations/service'
+import type { ServiceCreateInput, ServiceUpdateInput } from '@/lib/validations/service'
+import { success, failure, logError, getErrorMessage } from '@/lib/utils/errors'
+import type { ActionResult } from '@/lib/utils/errors'
+import type { Service } from '@/types/database'
 
 export async function getServices(filters?: {
-  status?: string
-  service_type?: string
+  estado?: string
+  tipo_servicio?: string
   date_from?: string
   date_to?: string
   cemetery_id?: string
   search?: string
-}): Promise<ActionResult<unknown[]>> {
-  try {
-    const supabase = await createClient()
+}) {
+  const supabase = await createClient()
 
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
 
-    if (!user) {
-      return failure('UNAUTHORIZED', 'No autenticado')
-    }
-
-    // Get user's funeral_home_id and accessible branches
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('funeral_home_id, role')
-      .eq('id', user.id)
-      .single()
-
-    if (!profile) {
-      return failure('NOT_FOUND', 'Perfil no encontrado')
-    }
-
-    const { data: userBranches } = await supabase
-      .from('user_branches')
-      .select('branch_id')
-      .eq('user_id', user.id)
-
-    const branchIds = userBranches?.map(ub => ub.branch_id) || []
-
-    let query = supabase
-      .from('services')
-      .select(`
-        *,
-        plan:plans(*),
-        coffin:coffin_urns!coffin_id(*),
-        urn:coffin_urns!urn_id(*),
-        cemetery:cemetery_crematoriums(*),
-        transactions(*)
-      `)
-      .eq('funeral_home_id', profile.funeral_home_id)
-      .order('created_at', { ascending: false })
-
-    if (branchIds.length > 0) {
-      query = query.in('branch_id', branchIds)
-    }
-
-    if (filters?.status) {
-      query = query.eq('status', filters.status)
-    }
-
-    if (filters?.service_type) {
-      query = query.eq('service_type', filters.service_type)
-    }
-
-    if (filters?.date_from) {
-      query = query.gte('burial_cremation_date', filters.date_from)
-    }
-
-    if (filters?.date_to) {
-      query = query.lte('burial_cremation_date', filters.date_to)
-    }
-
-    if (filters?.cemetery_id) {
-      query = query.eq('cemetery_crematorium_id', filters.cemetery_id)
-    }
-
-    if (filters?.search) {
-      // Sanitize search input to prevent SQL injection
-      const sanitizedSearch = filters.search.replace(/[%_\\]/g, '\\$&')
-      query = query.or(`deceased_name.ilike.%${sanitizedSearch}%,responsible_name.ilike.%${sanitizedSearch}%,service_number.ilike.%${sanitizedSearch}%`)
-    }
-
-    const { data, error } = await query
-
-    if (error) {
-      logError('getServices', error)
-      return failure(error.code || 'SERVER_ERROR', getErrorMessage(error))
-    }
-
-    return success(data || [])
-  } catch (error) {
-    logError('getServices', error)
-    return failure('SERVER_ERROR', getErrorMessage(error))
+  if (!user) {
+    throw new Error('No autenticado')
   }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('funeral_home_id, role')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile) {
+    throw new Error('Perfil no encontrado')
+  }
+
+  const { data: userBranches } = await supabase
+    .from('user_branches')
+    .select('branch_id')
+    .eq('user_id', user.id)
+
+  const branchIds = userBranches?.map((ub) => ub.branch_id) || []
+
+  let query = supabase
+    .from('services')
+    .select(
+      `
+      *,
+      plan:plans(*),
+      coffin:coffin_urns!coffin_id(*),
+      urn:coffin_urns!urn_id(*),
+      cemetery:cemetery_crematoriums(*),
+      transactions(*)
+    `
+    )
+    .eq('funeral_home_id', profile.funeral_home_id)
+    .order('created_at', { ascending: false })
+
+  if (branchIds.length > 0) {
+    query = query.in('branch_id', branchIds)
+  }
+
+  if (filters?.estado) {
+    query = query.eq('estado', filters.estado)
+  }
+
+  if (filters?.tipo_servicio) {
+    query = query.eq('tipo_servicio', filters.tipo_servicio)
+  }
+
+  if (filters?.date_from) {
+    query = query.gte('fecha_inhumacion_cremacion', filters.date_from)
+  }
+
+  if (filters?.date_to) {
+    query = query.lte('fecha_inhumacion_cremacion', filters.date_to)
+  }
+
+  if (filters?.cemetery_id) {
+    query = query.eq('cemetery_crematorium_id', filters.cemetery_id)
+  }
+
+  if (filters?.search) {
+    query = query.or(
+      `nombre_fallecido.ilike.%${filters.search}%,nombre_responsable.ilike.%${filters.search}%,numero_servicio.ilike.%${filters.search}%`
+    )
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    throw error
+  }
+
+  return data
 }
 
-export async function getService(id: string): Promise<ActionResult<unknown>> {
-  try {
-    const supabase = await createClient()
+export async function getService(id: string) {
+  const supabase = await createClient()
 
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
 
-    if (!user) {
-      return failure('UNAUTHORIZED', 'No autenticado')
-    }
-
-    const { data, error } = await supabase
-      .from('services')
-      .select(`
-        *,
-        plan:plans(*),
-        coffin:coffin_urns!coffin_id(*),
-        urn:coffin_urns!urn_id(*),
-        cemetery:cemetery_crematoriums(*),
-        main_vehicle:vehicles!main_vehicle_id(*),
-        service_items(*),
-        transactions(*),
-        service_assignments(
-          *,
-          collaborator:collaborators(*)
-        ),
-        mortuary_quota:mortuary_quotas(*),
-        documents(*),
-        service_procedures(*)
-      `)
-      .eq('id', id)
-      .single()
-
-    if (error) {
-      if (error.code === 'PGRST116') {
-        return failure('NOT_FOUND', 'Servicio no encontrado')
-      }
-      logError('getService', error)
-      return failure(error.code || 'SERVER_ERROR', getErrorMessage(error))
-    }
-
-    return success(data)
-  } catch (error) {
-    logError('getService', error)
-    return failure('SERVER_ERROR', getErrorMessage(error))
+  if (!user) {
+    throw new Error('No autenticado')
   }
+
+  const { data, error } = await supabase
+    .from('services')
+    .select(
+      `
+      *,
+      plan:plans(*),
+      coffin:coffin_urns!coffin_id(*),
+      urn:coffin_urns!urn_id(*),
+      cemetery:cemetery_crematoriums(*),
+      main_vehicle:vehicles!vehiculo_principal_id(*),
+      service_items(*),
+      transactions(*),
+      service_assignments(
+        *,
+        collaborator:collaborators(*)
+      ),
+      mortuary_quota:mortuary_quotas(*),
+      documents(*),
+      service_procedures(*)
+    `
+    )
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  return data
 }
 
-export async function createService(input: ServiceInput): Promise<ActionResult<unknown>> {
+export async function createService(input: ServiceCreateInput): Promise<ActionResult<Service>> {
   try {
     const supabase = await createClient()
 
@@ -162,21 +151,21 @@ export async function createService(input: ServiceInput): Promise<ActionResult<u
       return failure('UNAUTHORIZED', 'No autenticado')
     }
 
-    let validated
-    try {
-      validated = serviceSchema.parse(input)
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const fieldErrors = extractZodErrors(error)
-        return failure('VALIDATION_ERROR', 'Datos inválidos', fieldErrors)
-      }
-      throw error
+    const validationResult = serviceCreateSchema.safeParse(input)
+    if (!validationResult.success) {
+      return failure('VALIDATION_ERROR', 'Datos inválidos', validationResult.error.issues)
     }
+
+    const validated = validationResult.data
+
+    const cleanedData = Object.fromEntries(
+      Object.entries(validated).map(([key, value]) => [key, value === '' ? null : value])
+    )
 
     const { data, error } = await supabase
       .from('services')
       .insert({
-        ...validated,
+        ...cleanedData,
         created_by: user.id,
       })
       .select()
@@ -191,11 +180,14 @@ export async function createService(input: ServiceInput): Promise<ActionResult<u
     return success(data)
   } catch (error) {
     logError('createService', error)
-    return failure('SERVER_ERROR', getErrorMessage(error))
+    return failure('UNKNOWN_ERROR', getErrorMessage(error))
   }
 }
 
-export async function updateService(id: string, input: Partial<ServiceInput>): Promise<ActionResult<unknown>> {
+export async function updateService(
+  id: string,
+  input: ServiceUpdateInput
+): Promise<ActionResult<Service>> {
   try {
     const supabase = await createClient()
 
@@ -207,28 +199,25 @@ export async function updateService(id: string, input: Partial<ServiceInput>): P
       return failure('UNAUTHORIZED', 'No autenticado')
     }
 
-    let validated
-    try {
-      validated = serviceSchema.partial().parse(input)
-    } catch (error) {
-      if (error instanceof ZodError) {
-        const fieldErrors = extractZodErrors(error)
-        return failure('VALIDATION_ERROR', 'Datos inválidos', fieldErrors)
-      }
-      throw error
+    const validationResult = serviceUpdateSchema.safeParse(input)
+    if (!validationResult.success) {
+      return failure('VALIDATION_ERROR', 'Datos inválidos', validationResult.error.issues)
     }
+
+    const validated = validationResult.data
+
+    const cleanedData = Object.fromEntries(
+      Object.entries(validated).map(([key, value]) => [key, value === '' ? null : value])
+    )
 
     const { data, error } = await supabase
       .from('services')
-      .update(validated)
+      .update(cleanedData)
       .eq('id', id)
       .select()
       .single()
 
     if (error) {
-      if (error.code === 'PGRST116') {
-        return failure('NOT_FOUND', 'Servicio no encontrado')
-      }
       logError('updateService', error)
       return failure(error.code || 'SERVER_ERROR', getErrorMessage(error))
     }
@@ -238,7 +227,7 @@ export async function updateService(id: string, input: Partial<ServiceInput>): P
     return success(data)
   } catch (error) {
     logError('updateService', error)
-    return failure('SERVER_ERROR', getErrorMessage(error))
+    return failure('UNKNOWN_ERROR', getErrorMessage(error))
   }
 }
 
@@ -254,10 +243,7 @@ export async function deleteService(id: string): Promise<ActionResult<void>> {
       return failure('UNAUTHORIZED', 'No autenticado')
     }
 
-    const { error } = await supabase
-      .from('services')
-      .delete()
-      .eq('id', id)
+    const { error } = await supabase.from('services').delete().eq('id', id)
 
     if (error) {
       logError('deleteService', error)
@@ -268,7 +254,72 @@ export async function deleteService(id: string): Promise<ActionResult<void>> {
     return success(undefined)
   } catch (error) {
     logError('deleteService', error)
-    return failure('SERVER_ERROR', getErrorMessage(error))
+    return failure('UNKNOWN_ERROR', getErrorMessage(error))
   }
 }
 
+export async function getCatalogData() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    throw new Error('No autenticado')
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('funeral_home_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile) {
+    throw new Error('Perfil no encontrado')
+  }
+
+  const [plansResult, coffinsResult, urnsResult, cemeteriesResult, vehiclesResult] =
+    await Promise.all([
+      supabase
+        .from('plans')
+        .select('id, nombre, precio_base, descripcion')
+        .eq('funeral_home_id', profile.funeral_home_id)
+        .eq('estado_activo', true)
+        .order('nombre'),
+      supabase
+        .from('coffin_urns')
+        .select('id, nombre_comercial, precio_venta, categoria, tamano')
+        .eq('funeral_home_id', profile.funeral_home_id)
+        .eq('tipo', 'ataud')
+        .eq('estado_activo', true)
+        .order('nombre_comercial'),
+      supabase
+        .from('coffin_urns')
+        .select('id, nombre_comercial, precio_venta, categoria')
+        .eq('funeral_home_id', profile.funeral_home_id)
+        .eq('tipo', 'urna')
+        .eq('estado_activo', true)
+        .order('nombre_comercial'),
+      supabase
+        .from('cemetery_crematoriums')
+        .select('id, nombre, tipo, direccion')
+        .eq('funeral_home_id', profile.funeral_home_id)
+        .eq('estado_activo', true)
+        .order('nombre'),
+      supabase
+        .from('vehicles')
+        .select('id, placa, tipo_vehiculo, capacidad')
+        .eq('funeral_home_id', profile.funeral_home_id)
+        .eq('estado', 'disponible')
+        .order('placa'),
+    ])
+
+  return {
+    plans: plansResult.data || [],
+    coffins: coffinsResult.data || [],
+    urns: urnsResult.data || [],
+    cemeteries: cemeteriesResult.data || [],
+    vehicles: vehiclesResult.data || [],
+  }
+}


### PR DESCRIPTION
## Summary
- add a multistep ServiceForm component and new /servicios/nuevo page
- extend service detail and list views with richer catalog data and UI polish
- expand server actions and validation schemas for creating and updating services

## Testing
- npm run lint (fails: existing @typescript-eslint/no-explicit-any warnings on legacy files)
